### PR TITLE
LTI Redirection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ build/
 *.iml
 *.DS_Store
 src/main/resources/application.properties
+src/main/webapp/META-INF/*

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,11 @@
             <version>20140107</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.3</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>20.0</version>

--- a/src/main/java/edu/wisc/my/ltiproxy/LTIParameters.java
+++ b/src/main/java/edu/wisc/my/ltiproxy/LTIParameters.java
@@ -3,10 +3,6 @@ package edu.wisc.my.ltiproxy;
 import java.util.Collections;
 import java.util.Map;
 
-/**
- *
- * @author sibley
- */
 public class LTIParameters {
     private final String actionURL;
     private final Map<String, String> signedParameters;

--- a/src/main/java/edu/wisc/my/ltiproxy/LTIParameters.java
+++ b/src/main/java/edu/wisc/my/ltiproxy/LTIParameters.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package edu.wisc.my.ltiproxy;
 
 import java.util.Collections;

--- a/src/main/java/edu/wisc/my/ltiproxy/LTIParameters.java
+++ b/src/main/java/edu/wisc/my/ltiproxy/LTIParameters.java
@@ -1,0 +1,31 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package edu.wisc.my.ltiproxy;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ *
+ * @author sibley
+ */
+public class LTIParameters {
+    private final String actionURL;
+    private final Map<String, String> signedParameters;
+
+    public LTIParameters(String actionURL, Map<String, String> signedParameters) {
+        this.actionURL = actionURL;
+        this.signedParameters = Collections.unmodifiableMap(signedParameters);
+    }
+
+    public String getActionURL() {
+        return actionURL;
+    }
+
+    public Map<String, String> getSignedParameters() {
+        return signedParameters;
+    }
+}

--- a/src/main/java/edu/wisc/my/ltiproxy/service/LTILaunchService.java
+++ b/src/main/java/edu/wisc/my/ltiproxy/service/LTILaunchService.java
@@ -2,15 +2,16 @@ package edu.wisc.my.ltiproxy.service;
 
 import java.io.IOException;
 
-import javax.servlet.http.HttpServletRequest;
-
 import org.imsglobal.lti.launch.LtiSigningException;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import java.net.URI;
+import java.util.Map;
 
 public interface LTILaunchService {
-    public JSONObject getFormData(String launchKey, HttpServletRequest request) throws JsonParseException, JsonMappingException, IOException, LtiSigningException, JSONException;
+    public URI getRedirectUri(String launchKey, Map<String, String> headers) throws JsonParseException, JsonMappingException, IOException, LtiSigningException, JSONException;
+    public JSONObject getFormData(String launchKey, Map<String, String> headers) throws JsonParseException, JsonMappingException, IOException, LtiSigningException, JSONException;
 }

--- a/src/main/java/edu/wisc/my/ltiproxy/service/LTILaunchService.java
+++ b/src/main/java/edu/wisc/my/ltiproxy/service/LTILaunchService.java
@@ -9,9 +9,10 @@ import org.json.JSONObject;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Map;
 
 public interface LTILaunchService {
-    public URI getRedirectUri(String launchKey, Map<String, String> headers) throws JsonParseException, JsonMappingException, IOException, LtiSigningException, JSONException;
+    public URI getRedirectUri(String launchKey, Map<String, String> headers) throws JsonParseException, JsonMappingException, IOException, LtiSigningException, URISyntaxException;
     public JSONObject getFormData(String launchKey, Map<String, String> headers) throws JsonParseException, JsonMappingException, IOException, LtiSigningException, JSONException;
 }

--- a/src/main/java/edu/wisc/my/ltiproxy/service/LTILaunchServiceImpl.java
+++ b/src/main/java/edu/wisc/my/ltiproxy/service/LTILaunchServiceImpl.java
@@ -8,8 +8,6 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.Map.Entry;
 
-import javax.servlet.http.HttpServletRequest;
-
 import org.imsglobal.lti.launch.LtiOauthSigner;
 import org.imsglobal.lti.launch.LtiSigner;
 import org.imsglobal.lti.launch.LtiSigningException;
@@ -21,11 +19,24 @@ import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import edu.wisc.my.ltiproxy.LTIParameters;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
 
 @Service
 public class LTILaunchServiceImpl implements LTILaunchService{
     
+    private RestTemplate rest = new RestTemplate();
     private LTILaunchPropertyFileDao LTILaunchPropertyFileDao;
+    
+    private static final String UTF8 = StandardCharsets.UTF_8.name();
     
     @Autowired
     void setLTILaunchProperityFileDao(LTILaunchPropertyFileDao LTILaunchPropertyFileDao){
@@ -33,26 +44,36 @@ public class LTILaunchServiceImpl implements LTILaunchService{
     }
 
     @Override
-    public JSONObject getFormData(String key, HttpServletRequest request) throws
+    public URI getRedirectUri (String key, Map<String, String> headers) throws
+        JsonParseException, JsonMappingException, IOException, LtiSigningException, JSONException {
+        URI result;
+        
+        Map<String, String> prepParams = prepareParameters(key, headers);
+        LTIParameters ltiParams = signParameters(key, prepParams);
+        
+        String actionUrl = ltiParams.getActionURL();
+        String formBody = buildFormBody(ltiParams.getSignedParameters());
+        HttpHeaders ltiHeaders = new HttpHeaders();
+        ltiHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        HttpEntity<String> ltiReq = new HttpEntity<>(formBody);
+        
+        ResponseEntity<String> ltiResp = rest.exchange(actionUrl, HttpMethod.POST, ltiReq, String.class);
+        result = ltiResp.getHeaders().getLocation();
+        
+        return result;
+    }
+    
+    @Override
+    public JSONObject getFormData(String key, Map<String, String> headers) throws
         JsonParseException, JsonMappingException, IOException, LtiSigningException, JSONException {
         
-        Map<String, String> launchParameters = LTILaunchPropertyFileDao.getLaunchParameters(key);
-        
-        TreeMap<String, String> paramsToSign = new TreeMap<String, String>();
-        paramsToSign.putAll(launchParameters);
-        paramsToSign.putAll(getHeaders(key, request));
-        
-        LtiSigner ltiSigner = new LtiOauthSigner();
-        String ltiKey = LTILaunchPropertyFileDao.getProperty(key, "key");
-        String ltiSecret = LTILaunchPropertyFileDao.getProperty(key, "secret");
-        String ltiActionUrl = LTILaunchPropertyFileDao.getProperty(key, "actionURL");
-        Map<String, String> signedParameters = ltiSigner.signParameters(
-                paramsToSign, ltiKey, ltiSecret, ltiActionUrl, "POST");
+        Map<String, String> prepParams = prepareParameters(key, headers);
+        LTIParameters ltiParams = signParameters(key, prepParams);
 
         JSONObject jsonToReturn = new JSONObject();
-        jsonToReturn.put("action", ltiActionUrl);
+        jsonToReturn.put("action", ltiParams.getActionURL());
         JSONArray formInputs = new JSONArray();
-        for(Entry<String, String> entry : signedParameters.entrySet()){
+        for(Entry<String, String> entry : ltiParams.getSignedParameters().entrySet()){
             JSONObject entryObject = new JSONObject();
             entryObject.put("name", entry.getKey());
             entryObject.put("value", entry.getValue());
@@ -63,14 +84,39 @@ public class LTILaunchServiceImpl implements LTILaunchService{
         return jsonToReturn;
     }
     
-    private Map<String, String> getHeaders (String key, HttpServletRequest request) throws JsonParseException, JsonMappingException, IOException{
-        Map<String, String> headers = new HashMap<String, String>();
+    private Map<String, String> prepareParameters(String key, Map<String, String> requestHeaders) throws 
+            JsonParseException, JsonMappingException, IOException, LtiSigningException, JSONException {
+        Map<String, String> launchParameters = LTILaunchPropertyFileDao.getLaunchParameters(key);
+        
+        Map<String, String> paramsToSign = new TreeMap<>();
+        paramsToSign.putAll(launchParameters);
+        paramsToSign.putAll(replaceHeaders(key, requestHeaders));
+        
+        return paramsToSign;
+    }
+    
+    private LTIParameters signParameters(String key, Map<String, String> paramsToSign) throws LtiSigningException {
+        LTIParameters result;
+        
+        LtiSigner ltiSigner = new LtiOauthSigner();
+        String ltiKey = LTILaunchPropertyFileDao.getProperty(key, "key");
+        String ltiSecret = LTILaunchPropertyFileDao.getProperty(key, "secret");
+        String ltiActionUrl = LTILaunchPropertyFileDao.getProperty(key, "actionURL");
+        Map<String, String> signedParameters = ltiSigner.signParameters(
+                paramsToSign, ltiKey, ltiSecret, ltiActionUrl, "POST");
+        result = new LTIParameters(ltiActionUrl, signedParameters);
+        
+        return result;
+    }
+    
+    private Map<String, String> replaceHeaders (String key, Map<String, String> requestHeaders) throws JsonParseException, JsonMappingException, IOException{
+        Map<String, String> headers = new HashMap<>();
         Map<String, String[]> headersToReplace = LTILaunchPropertyFileDao.getHeadersToReplace(key);
         for( String headerToReplace : headersToReplace.keySet()){
           String[] headerAttributes = headersToReplace.get(headerToReplace);
           for(String header : headerAttributes){
-            if(request.getHeader(header)!=null){
-                headers.put(headerToReplace, request.getHeader(header));
+            if(requestHeaders.get(header)!=null){
+                headers.put(headerToReplace, requestHeaders.get(header));
               break;
             }
           }
@@ -78,4 +124,17 @@ public class LTILaunchServiceImpl implements LTILaunchService{
         return headers;
     }
     
+    private String buildFormBody(Map<String, String> parameters) throws UnsupportedEncodingException {
+        StringBuilder result = new StringBuilder();
+        
+        for (Entry<String, String> param : parameters.entrySet()) {
+            result.append("&")
+                    .append(param.getKey()) //TODO urlencode?
+                    .append("=")
+                    .append(param.getValue());
+        }
+        result.deleteCharAt(0);
+        
+        return result.toString();
+    }
 }

--- a/src/main/java/edu/wisc/my/ltiproxy/service/LTILaunchServiceImpl.java
+++ b/src/main/java/edu/wisc/my/ltiproxy/service/LTILaunchServiceImpl.java
@@ -37,6 +37,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.HttpHeaders;
+import org.apache.http.HttpStatus;
 import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,7 +88,7 @@ public class LTILaunchServiceImpl implements LTILaunchService{
             
             logger.trace(new String(b));
             
-            if (303 == status) {
+            if (HttpStatus.SC_SEE_OTHER == status) {
                 String loc = httpResp.getLastHeader(HttpHeaders.LOCATION).getValue();
                 logger.trace(loc);
                 result = new URI(loc);

--- a/src/main/java/edu/wisc/my/ltiproxy/web/LTIController.java
+++ b/src/main/java/edu/wisc/my/ltiproxy/web/LTIController.java
@@ -4,6 +4,7 @@ import edu.wisc.my.ltiproxy.service.LTILaunchService;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -36,7 +37,7 @@ public class LTIController {
 
   @RequestMapping(value="/go/{key}", method=RequestMethod.GET)
   public void proxyRedirect(HttpServletRequest request, HttpServletResponse response, @PathVariable String key) throws 
-          ClientProtocolException, IOException, LtiSigningException, JSONException {
+          ClientProtocolException, IOException, LtiSigningException, URISyntaxException {
       int statusCode = HttpServletResponse.SC_BAD_REQUEST;
       
       URI uri = LTILaunchService.getRedirectUri(key, getHeaders(request));

--- a/src/main/java/edu/wisc/my/ltiproxy/web/LTIController.java
+++ b/src/main/java/edu/wisc/my/ltiproxy/web/LTIController.java
@@ -3,6 +3,10 @@ package edu.wisc.my.ltiproxy.web;
 import edu.wisc.my.ltiproxy.service.LTILaunchService;
 
 import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -12,6 +16,7 @@ import org.imsglobal.lti.launch.LtiSigningException;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.env.EnumerableCompositePropertySource;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,13 +35,35 @@ public class LTIController {
       this.LTILaunchService = LTILaunchService;
   }
 
-
-  @RequestMapping(value="/{key}", method=RequestMethod.GET)
-  public @ResponseBody Object proxyResource(HttpServletRequest request, HttpServletResponse response, @PathVariable String key) throws ClientProtocolException, IOException, LtiSigningException, JSONException {
-
-     JSONObject jsonToReturn = LTILaunchService.getFormData(key, request);
-     response.setStatus(HttpServletResponse.SC_OK);
-     return jsonToReturn.toString();
+  @RequestMapping(value="/go/{key}", method=RequestMethod.GET)
+  public void proxyRedirect(HttpServletRequest request, HttpServletResponse response, @PathVariable String key) throws 
+          ClientProtocolException, IOException, LtiSigningException, JSONException {
+      int statusCode = HttpServletResponse.SC_BAD_REQUEST;
+      
+      URI uri = LTILaunchService.getRedirectUri(key, getHeaders(request));
+      
+      if (null != uri) {
+          response.sendRedirect(uri.toString());
+      } else {
+          response.sendError(statusCode, "Could not build redirect URI!");
+      }
   }
 
+  @RequestMapping(value="/{key}", method=RequestMethod.GET)
+  public @ResponseBody Object proxyResource(HttpServletRequest request, HttpServletResponse response, @PathVariable String key) throws 
+          ClientProtocolException, IOException, LtiSigningException, JSONException {
+      JSONObject jsonToReturn = LTILaunchService.getFormData(key, getHeaders(request));
+      response.setStatus(HttpServletResponse.SC_OK);
+      return jsonToReturn.toString();
+  }
+
+  private Map<String, String> getHeaders(HttpServletRequest req) {
+      Map<String, String> result = new HashMap<>();
+      
+      for (String headerName : Collections.list(req.getHeaderNames())) {
+          result.put(headerName, req.getHeader(headerName));
+      }
+      
+      return result;
+  }
 }

--- a/src/main/java/edu/wisc/my/ltiproxy/web/LTIController.java
+++ b/src/main/java/edu/wisc/my/ltiproxy/web/LTIController.java
@@ -16,7 +16,6 @@ import org.imsglobal.lti.launch.LtiSigningException;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.env.EnumerableCompositePropertySource;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/edu/wisc/my/ltiproxy/web/LTIController.java
+++ b/src/main/java/edu/wisc/my/ltiproxy/web/LTIController.java
@@ -1,5 +1,6 @@
 package edu.wisc.my.ltiproxy.web;
 
+import com.google.common.base.Strings;
 import edu.wisc.my.ltiproxy.service.LTILaunchService;
 
 import java.io.IOException;
@@ -38,14 +39,13 @@ public class LTIController {
   @RequestMapping(value="/go/{key}", method=RequestMethod.GET)
   public void proxyRedirect(HttpServletRequest request, HttpServletResponse response, @PathVariable String key) throws 
           ClientProtocolException, IOException, LtiSigningException, URISyntaxException {
-      int statusCode = HttpServletResponse.SC_BAD_REQUEST;
-      
       URI uri = LTILaunchService.getRedirectUri(key, getHeaders(request));
       
       if (null != uri) {
           response.sendRedirect(uri.toString());
       } else {
-          response.sendError(statusCode, "Could not build redirect URI!");
+          String errorMsg = "Could not build redirect URI" + ((!Strings.isNullOrEmpty(key))?" for "+key: "");
+          response.sendError(HttpServletResponse.SC_BAD_REQUEST, errorMsg);
       }
   }
 


### PR DESCRIPTION
~~This is broken, I'm just opening a pull request to start a code review~~

I refactored a bit of the existing code and started writing a redirector.

The refactors were pulling HttpServletRequest from the Service scope, and pulling some common prep logic out to be used by the redirector.  These should make unit testing the Service methods easier (though I haven't written any yet :man_shrugging:)

~~The redirector is using the Spring Web's built in RestTemplate to hit the remote url.  I opted to go with that over HttpComponents just to learn something new and to not pull in a dependency if I didn't need to.  However, as it's written now, I'm getting a 501 back from the external service, so I may pull in HttpComponents just for the extra debugging information I know I can get out of it.~~

I looked at the rssToJson microservice and swapped in HttpComponents per that.  Everything's a whole lot simpler.  Locally I'm getting a 400 from the external service, but that's probably because I don't have true authentication set up.  The real test of this will be out on predev.