### PR TITLE
WCP-452 Using order preserving collections

### DIFF
--- a/src/main/java/edu/wisc/my/ltiproxy/dao/LTILaunchPropertyFileDaoImpl.java
+++ b/src/main/java/edu/wisc/my/ltiproxy/dao/LTILaunchPropertyFileDaoImpl.java
@@ -1,7 +1,6 @@
 package edu.wisc.my.ltiproxy.dao;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,9 +11,11 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.HashMultimap;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 
 @Repository
 public class LTILaunchPropertyFileDaoImpl implements LTILaunchPropertyFileDao{
@@ -33,15 +34,15 @@ public class LTILaunchPropertyFileDaoImpl implements LTILaunchPropertyFileDao{
     @Override
     public Map<String, String> getLaunchParameters(String key) throws JsonParseException, JsonMappingException, IOException {
         String loadedSignedParams = env.getProperty(key+".launchParams");
-        HashMap<String, String> loadedSignedParamMap = mapper.readValue(loadedSignedParams, new TypeReference<Map<String, String>>(){});
+        LinkedHashMap<String, String> loadedSignedParamMap = mapper.readValue(loadedSignedParams, new TypeReference<Map<String, String>>(){});
         return loadedSignedParamMap;
     }
 
     @Override
     public Multimap<String, String> getHeadersToReplace(String launchKey) throws JsonParseException, JsonMappingException, IOException {
         String headerReplacementVariables = env.getProperty(launchKey+".headerReplacement");
-        HashMap<String, String> rawHeaderReplacementVariablesMap = mapper.readValue(headerReplacementVariables, new TypeReference<Map<String, String>>(){});
-        HashMultimap<String, String> headerReplacementVariableMap = HashMultimap.create();
+        LinkedHashMap<String, String> rawHeaderReplacementVariablesMap = mapper.readValue(headerReplacementVariables, new TypeReference<Map<String, String>>(){});
+        ListMultimap<String, String> headerReplacementVariableMap = LinkedListMultimap.create();
         for( String key : rawHeaderReplacementVariablesMap.keySet()){
             String headersString = rawHeaderReplacementVariablesMap.get(key);
             String [] headers = headersString.split(",");

--- a/src/main/java/edu/wisc/my/ltiproxy/service/LTILaunchServiceImpl.java
+++ b/src/main/java/edu/wisc/my/ltiproxy/service/LTILaunchServiceImpl.java
@@ -3,7 +3,6 @@ package edu.wisc.my.ltiproxy.service;
 import edu.wisc.my.ltiproxy.dao.LTILaunchPropertyFileDao;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.Map.Entry;
@@ -25,6 +24,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -151,7 +151,7 @@ public class LTILaunchServiceImpl implements LTILaunchService {
     }
 
     protected Map<String, String> replaceHeaders(String key, Map<String, String> requestHeaders) throws JsonParseException, JsonMappingException, IOException {
-        Map<String, String> result = new HashMap<>();
+        Map<String, String> result = new LinkedHashMap<>();
         Multimap<String, String> paramToHeaders = LTILaunchPropertyFileDao.getHeadersToReplace(key);
         for (String param : paramToHeaders.keySet()) {
             Iterable<String> headers = paramToHeaders.get(param);

--- a/src/main/java/edu/wisc/my/ltiproxy/web/LTIController.java
+++ b/src/main/java/edu/wisc/my/ltiproxy/web/LTIController.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -58,7 +58,7 @@ public class LTIController {
     }
 
     public static Map<String, String> getHeaders(HttpServletRequest req) {
-        Map<String, String> result = new HashMap<>();
+        Map<String, String> result = new LinkedHashMap<>();
         for (String headerName : Collections.list(req.getHeaderNames())) {
             result.put(headerName.toLowerCase(), req.getHeader(headerName));
         }

--- a/src/test/java/edu/wisc/my/ltiproxy/dao/LTILaunchPropertyFileDaoImplTest.java
+++ b/src/test/java/edu/wisc/my/ltiproxy/dao/LTILaunchPropertyFileDaoImplTest.java
@@ -1,8 +1,8 @@
 package edu.wisc.my.ltiproxy.dao;
 
-import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -40,7 +40,7 @@ public class LTILaunchPropertyFileDaoImplTest {
         
         expectedActionURL = "http://localhost:8080/lti";
         
-        expectedLaunchParameters = new HashMap<>();
+        expectedLaunchParameters = new LinkedHashMap<>();
         expectedLaunchParameters.put("context_id", "test");
         expectedLaunchParameters.put("context_label", "test");
         expectedLaunchParameters.put("context_title", "test");
@@ -60,13 +60,15 @@ public class LTILaunchPropertyFileDaoImplTest {
         expectedLaunchParameters.put("tool_consumer_info_version", "10.6.0");
         expectedLaunchParameters.put("user_id", "");
         
-        expectedHeadersToReplace = HashMultimap.create();
+        expectedHeadersToReplace = ArrayListMultimap.create();
         expectedHeadersToReplace.put("lis_person_contact_email_primary", "mail");
         expectedHeadersToReplace.put("lis_person_name_family", "eduWisconsinSurname");
         expectedHeadersToReplace.put("lis_person_name_family", "wiscEduSORLastName");
         expectedHeadersToReplace.put("lis_person_name_full", "eduWisconsinCommonName");
+        expectedHeadersToReplace.put("lis_person_name_full", "displayName");
         expectedHeadersToReplace.put("lis_person_name_full", "uid");
         expectedHeadersToReplace.put("lis_person_name_given", "eduWisconsinGivenName");
+        expectedHeadersToReplace.put("lis_person_name_given", "givenName");
         expectedHeadersToReplace.put("user_id", "eduWisconsinSPVI");
         expectedHeadersToReplace.put("user_id", "wiscEduPVI");
 

--- a/src/test/java/edu/wisc/my/ltiproxy/dao/LTILaunchPropertyFileDaoImplTest.java
+++ b/src/test/java/edu/wisc/my/ltiproxy/dao/LTILaunchPropertyFileDaoImplTest.java
@@ -1,6 +1,6 @@
 package edu.wisc.my.ltiproxy.dao;
 
-import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Multimap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -60,7 +60,7 @@ public class LTILaunchPropertyFileDaoImplTest {
         expectedLaunchParameters.put("tool_consumer_info_version", "10.6.0");
         expectedLaunchParameters.put("user_id", "");
         
-        expectedHeadersToReplace = ArrayListMultimap.create();
+        expectedHeadersToReplace = LinkedListMultimap.create();
         expectedHeadersToReplace.put("lis_person_contact_email_primary", "mail");
         expectedHeadersToReplace.put("lis_person_name_family", "eduWisconsinSurname");
         expectedHeadersToReplace.put("lis_person_name_family", "wiscEduSORLastName");

--- a/src/test/java/edu/wisc/my/ltiproxy/service/LTILaunchServiceImplTest.java
+++ b/src/test/java/edu/wisc/my/ltiproxy/service/LTILaunchServiceImplTest.java
@@ -4,12 +4,11 @@ import edu.wisc.my.ltiproxy.LTIParameters;
 import edu.wisc.my.ltiproxy.dao.LTILaunchPropertyFileDao;
 import edu.wisc.my.ltiproxy.web.LTIController;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicNameValuePair;
-import org.hamcrest.core.IsCollectionContaining;
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -25,7 +24,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.util.CollectionUtils;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -69,16 +67,18 @@ public class LTILaunchServiceImplTest {
         exampleReq.addHeader("isMemberOf", "uw:domain:my.wisc.edu:my_uw_administrators;uw:domain:ohr.wisc.edu:trems;uw:domain:apps.mumaa.doit.wisc.edu:lumen_access;uw:domain:my.wisc.edu:my_uw_hr_officers");
         exampleReq.addHeader("mail", "TESTMAN@WISC.EDU");
         exampleReq.addHeader("pubcookie-user", "testman");
+        exampleReq.addHeader("givenName", "TESTY WISC");
         exampleReq.addHeader("uid", "testman");
         exampleReq.addHeader("wiscEduHRPersonID", "01234567");
         exampleReq.addHeader("wiscEduHRSEmplID", "01234567");
         exampleReq.addHeader("wiscEduISISEmplID", "0123456789");
         exampleReq.addHeader("wiscEduPVI", "UW123B456");
+        exampleReq.addHeader("displayName", "TESTY WISC TESTMAN");
         exampleReq.addHeader("wiscEduSORLastName", "TESTMAN");
         exampleReq.addHeader("wiscEduWiscardAccountNumber", "01234567890");
-        exampleReq.addHeader("eduWisconsinGivenName", "TESTY TESTMAN");
+        exampleReq.addHeader("eduWisconsinGivenName", "TESTY WISCONSIN");
         
-        exampleHeaders = new HashMap<>();
+        exampleHeaders = new LinkedHashMap<>();
         exampleHeaders.put("host", "localhost:8080");
         exampleHeaders.put("connection", "keep-alive");
         exampleHeaders.put("pragma", "no-cache");
@@ -94,16 +94,18 @@ public class LTILaunchServiceImplTest {
         exampleHeaders.put("ismemberof", "uw:domain:my.wisc.edu:my_uw_administrators;uw:domain:ohr.wisc.edu:trems;uw:domain:apps.mumaa.doit.wisc.edu:lumen_access;uw:domain:my.wisc.edu:my_uw_hr_officers");
         exampleHeaders.put("mail", "TESTMAN@WISC.EDU");
         exampleHeaders.put("pubcookie-user", "testman");
+        exampleHeaders.put("givenname", "TESTY WISC");
         exampleHeaders.put("uid", "testman");
         exampleHeaders.put("wisceduhrpersonid", "01234567");
         exampleHeaders.put("wisceduhrsemplid", "01234567");
         exampleHeaders.put("wisceduisisemplid", "0123456789");
         exampleHeaders.put("wiscedupvi", "UW123B456");
+        exampleHeaders.put("displayname", "TESTY WISC TESTMAN");
         exampleHeaders.put("wiscedusorlastname", "TESTMAN");
         exampleHeaders.put("wisceduwiscardaccountnumber", "01234567890");
-        exampleHeaders.put("eduwisconsingivenname", "TESTY TESTMAN");
+        exampleHeaders.put("eduwisconsingivenname", "TESTY WISCONSIN");
         
-        expectedPreparedParameters = new HashMap<>();
+        expectedPreparedParameters = new LinkedHashMap<>();
         expectedPreparedParameters.put("context_id", "test");
         expectedPreparedParameters.put("context_label", "test");
         expectedPreparedParameters.put("context_title", "test");
@@ -112,8 +114,8 @@ public class LTILaunchServiceImplTest {
         expectedPreparedParameters.put("lis_outcome_service_url", "http://localhost:8080/d2l/le/lti/Outcome");
         expectedPreparedParameters.put("lis_person_contact_email_primary", "TESTMAN@WISC.EDU");
         expectedPreparedParameters.put("lis_person_name_family", "TESTMAN");
-        expectedPreparedParameters.put("lis_person_name_full", "testman");
-        expectedPreparedParameters.put("lis_person_name_given", "TESTY TESTMAN");
+        expectedPreparedParameters.put("lis_person_name_full", "TESTY WISC TESTMAN");
+        expectedPreparedParameters.put("lis_person_name_given", "TESTY WISCONSIN");
         expectedPreparedParameters.put("lti_message_type", "basic-lti-launch-request");
         expectedPreparedParameters.put("lti_version", "LTI-1p0");
         expectedPreparedParameters.put("resource_link_description", "MyUW Blackboard Ultra Collaborate LTI Launcher");
@@ -123,15 +125,15 @@ public class LTILaunchServiceImplTest {
         expectedPreparedParameters.put("tool_consumer_info_version", "10.6.0");
         expectedPreparedParameters.put("user_id", "UW123B456");
         
-        expectedReplacedHeaders = new HashMap<>();
+        expectedReplacedHeaders = new LinkedHashMap<>();
         expectedReplacedHeaders.put("lis_person_contact_email_primary", "TESTMAN@WISC.EDU");
         expectedReplacedHeaders.put("lis_person_name_family", "TESTMAN");
-        expectedReplacedHeaders.put("lis_person_name_full", "testman");
-        expectedReplacedHeaders.put("lis_person_name_given", "TESTY TESTMAN");
+        expectedReplacedHeaders.put("lis_person_name_full", "TESTY WISC TESTMAN");
+        expectedReplacedHeaders.put("lis_person_name_given", "TESTY WISCONSIN");
         expectedReplacedHeaders.put("user_id", "UW123B456");
         
         actionURL = "http://localhost:8080/lti";
-        expectedSignedParameters = new HashMap<>();
+        expectedSignedParameters = new LinkedHashMap<>();
         expectedSignedParameters.put("oauth_nonce", "179248056711247"); //UNIQUE
         expectedSignedParameters.put("oauth_signature", "9gf64nLk+8IAsEbpxMozwaKuOng="); //UNIQUE
         expectedSignedParameters.put("oauth_consumer_key", "TESTKEY");

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -29,7 +29,7 @@ test.actionURL=http://localhost:8080/lti
 test.headerReplacement = \
 {"lis_person_contact_email_primary" : "mail"\
 ,"lis_person_name_family" : "eduWisconsinSurname,wiscEduSORLastName"\
-,"lis_person_name_full" : "eduWisconsinCommonName,uid"\
-,"lis_person_name_given" : "eduWisconsinGivenName"\
+,"lis_person_name_full" : "eduWisconsinCommonName,displayName,uid"\
+,"lis_person_name_given" : "eduWisconsinGivenName,givenName"\
 ,"user_id" : "eduWisconsinSPVI,wiscEduPVI"\
 }


### PR DESCRIPTION
Found the issue when more than one header was provided, it was inconsistent as to which header would be used for the replacement. Switched collections over to insertion order preserving versions, and everything's lookin good.