### PR TITLE
WCP-452 handling blank headers

### DIFF
--- a/src/main/java/edu/wisc/my/ltiproxy/service/LTILaunchServiceImpl.java
+++ b/src/main/java/edu/wisc/my/ltiproxy/service/LTILaunchServiceImpl.java
@@ -26,6 +26,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;
@@ -157,7 +158,7 @@ public class LTILaunchServiceImpl implements LTILaunchService {
             Iterable<String> headers = paramToHeaders.get(param);
             for (String headerKey : headers) {
                 String headerValue = requestHeaders.get(headerKey.toLowerCase());
-                if (null != headerValue) {
+                if (StringUtils.isNotBlank(headerValue)) {
                     result.put(param, headerValue);
                     break;
                 }

--- a/src/test/java/edu/wisc/my/ltiproxy/service/LTILaunchServiceImplTest.java
+++ b/src/test/java/edu/wisc/my/ltiproxy/service/LTILaunchServiceImplTest.java
@@ -77,6 +77,7 @@ public class LTILaunchServiceImplTest {
         exampleReq.addHeader("wiscEduSORLastName", "TESTMAN");
         exampleReq.addHeader("wiscEduWiscardAccountNumber", "01234567890");
         exampleReq.addHeader("eduWisconsinGivenName", "TESTY WISCONSIN");
+        exampleReq.addHeader("eduWisconsinSPVI", "");
         
         exampleHeaders = new LinkedHashMap<>();
         exampleHeaders.put("host", "localhost:8080");
@@ -104,6 +105,7 @@ public class LTILaunchServiceImplTest {
         exampleHeaders.put("wiscedusorlastname", "TESTMAN");
         exampleHeaders.put("wisceduwiscardaccountnumber", "01234567890");
         exampleHeaders.put("eduwisconsingivenname", "TESTY WISCONSIN");
+        exampleHeaders.put("eduwisconsinspvi", "");
         
         expectedPreparedParameters = new LinkedHashMap<>();
         expectedPreparedParameters.put("context_id", "test");


### PR DESCRIPTION
Apparently, if there aren't values for specific headers, they're not omitted, they're empty. Fixing the ordering bug revealed that PVI will be set to empty in Madison.

Moral of the story: If you don't have a test for it, it doesn't do what you think it does.